### PR TITLE
Feature: add ability to filter instruments and contracts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ See the official documentation of the End Point at https://www.interactivebroker
      - ``Get portfolio/accounts``
      - ``list``
    * - ``switch_account(accountId: str)``
-     - ``Post iserver/account/{accoutId}``
+     - ``Post iserver/account/{accountId}``
      - ``dict``
    * - ``get_cash()``
      - ``Get portfolio/{accountId}/ledger``


### PR DESCRIPTION
`get_conid` by default returns the first contract of the first instrument it finds. This causes problems if multiple markets have instruments using this symbol, as a contract different from what was expected might be returned. I found this when looking up the $MUB US equity, which is not the first $MUB instrument returned by IB, so I didn't receive the contract ID I wanted.

Two parameters, `instrument_filters` and `contract_filters`, are added to `get_conid`. `instrument_filters` filters the instrument data, i.e. the `name`, `chineseName`, and `assetClass` fields. `contract_filters` filters the contract data, i.e the `exchange` and `isUS` fields. All filters must be fulfilled for the instrument/contract to be included. The filters can be used together.

I've added some samples of searching for US $MUB using the filters.