### PR TITLE
Using BASE instead of hardcoded USD currency

### DIFF
--- a/src/easyib/easyib.py
+++ b/src/easyib/easyib.py
@@ -61,19 +61,19 @@ class REST:
             f"{self.url}portfolio/{self.id}/ledger", verify=self.ssl
         )
 
-        return response.json()["USD"]["cashbalance"]
+        return response.json()["BASE"]["cashbalance"]
 
     def get_netvalue(self) -> float:
         """Returns net value of the selected account
 
-        :return: Net value in USD
+        :return: Net value in BASE
         :rtype: float
         """
         response = requests.get(
             f"{self.url}portfolio/{self.id}/ledger", verify=self.ssl
         )
 
-        return response.json()["USD"]["netliquidationvalue"]
+        return response.json()["BASE"]["netliquidationvalue"]
 
     def get_conid(
         self,
@@ -142,7 +142,7 @@ class REST:
         )
 
         dic = {item["contractDesc"]: item["position"] for item in response.json()}
-        dic["USD"] = self.get_cash()
+        dic["BASE"] = self.get_cash()
         return dic
 
     def reply_yes(self, id: str) -> dict:


### PR DESCRIPTION
There is hardcoded `USD` currency in several methods, which causes problems with accounts of different than USD currency. We can use `BASE` - which represents base currency of the account. In case of holding multiple currencies this will also reflect to the total cash value represented by the BASE currency.